### PR TITLE
Add Population Density Field to City Data Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 A coding challenge solution
 
-## Server Setup
+## Server
 
 - server/index.js: Initializes an Express server and defines the `/api/cities` endpoint.
 
 ### Endpoints
 
-- GET `/api/cities`: Returns a list of cities. The data is read from cities.json file located in the project root.
+- GET `/api/cities`: Returns a list of cities. The data is read from cities.json file located in the project root and enriched with a population `density` field.
 
 #### Parameters
 

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "jest",
+    "test": "jest --no-cache --watchAll",
     "build": "npx tsc",
     "start": "node dist/index.js",
     "dev": "concurrently \"npx tsc --watch\" \"nodemon -q dist/index.js\""

--- a/server/tests/results.json
+++ b/server/tests/results.json
@@ -1,217 +1,1292 @@
 [
-  { "name": "New York", "area": 468.9, "population": 8398748 },
-  { "name": "Los Angeles", "area": 468.7, "population": 3990456 },
-  { "name": "Chicago", "area": 227.3, "population": 2705994 },
-  { "name": "Houston", "area": 599.6, "population": 2320268 },
-  { "name": "Phoenix", "area": 517.6, "population": 1680992 },
-  { "name": "Philadelphia", "area": 369.4, "population": 1584064 },
-  { "name": "San Antonio", "area": 461, "population": 1547253 },
-  { "name": "San Diego", "area": 325.2, "population": 1423851 },
-  { "name": "Dallas", "area": 340.5, "population": 1343573 },
-  { "name": "San Jose", "area": 461.5, "population": 1030119 },
-  { "name": "Austin", "area": 312.7, "population": 964254 },
-  { "name": "Jacksonville", "area": 874.6, "population": 903889 },
-  { "name": "Fort Worth", "area": 347.2, "population": 895008 },
-  { "name": "Columbus", "area": 560.5, "population": 892533 },
-  { "name": "Charlotte", "area": 306.6, "population": 885708 },
-  { "name": "San Francisco", "area": 121.4, "population": 883305 },
-  { "name": "Indianapolis", "area": 368.2, "population": 877584 },
-  { "name": "Seattle", "area": 217.2, "population": 753675 },
-  { "name": "Denver", "area": 401.2, "population": 727211 },
-  { "name": "Washington", "area": 177, "population": 705749 },
-  { "name": "Boston", "area": 89.6, "population": 694583 },
-  { "name": "El Paso", "area": 255.2, "population": 681728 },
-  { "name": "Nashville", "area": 475, "population": 670820 },
-  { "name": "Detroit", "area": 370, "population": 670031 },
-  { "name": "Oklahoma City", "area": 620.3, "population": 655057 },
-  { "name": "Portland", "area": 133.5, "population": 654741 },
-  { "name": "Las Vegas", "area": 352, "population": 651319 },
-  { "name": "Memphis", "area": 317.4, "population": 650618 },
-  { "name": "Louisville", "area": 263.5, "population": 617638 },
-  { "name": "Baltimore", "area": 80.9, "population": 593490 },
-  { "name": "Milwaukee", "area": 249.9, "population": 590157 },
-  { "name": "Albuquerque", "area": 188.2, "population": 560218 },
-  { "name": "Tucson", "area": 230.8, "population": 548073 },
-  { "name": "Fresno", "area": 114.6, "population": 538330 },
-  { "name": "Mesa", "area": 325.5, "population": 528159 },
-  { "name": "Sacramento", "area": 97.9, "population": 513624 },
-  { "name": "Atlanta", "area": 343, "population": 506811 },
-  { "name": "Kansas City", "area": 319, "population": 495327 },
-  { "name": "Colorado Springs", "area": 195.6, "population": 478221 },
-  { "name": "Miami", "area": 55.2, "population": 467963 },
-  { "name": "Raleigh", "area": 146.9, "population": 464485 },
-  { "name": "Omaha", "area": 133.4, "population": 465112 },
-  { "name": "Long Beach", "area": 134, "population": 470130 },
-  { "name": "Virginia Beach", "area": 245.6, "population": 452745 },
-  { "name": "Oakland", "area": 55.9, "population": 440646 },
-  { "name": "Minneapolis", "area": 142.9, "population": 429606 },
-  { "name": "Tulsa", "area": 196.8, "population": 413066 },
-  { "name": "Arlington", "area": 99, "population": 398854 },
-  { "name": "New Orleans", "area": 169.4, "population": 390845 },
-  { "name": "Wichita", "area": 159.3, "population": 389255 },
-  { "name": "Cleveland", "area": 77.7, "population": 381009 },
-  { "name": "Tampa", "area": 170.6, "population": 377165 },
-  { "name": "Bakersfield", "area": 142.6, "population": 373640 },
-  { "name": "Aurora", "area": 154.6, "population": 372375 },
-  { "name": "Anaheim", "area": 50, "population": 359339 },
-  { "name": "Honolulu", "area": 68.4, "population": 345064 },
-  { "name": "Santa Ana", "area": 27.5, "population": 332725 },
-  { "name": "Corpus Christi", "area": 380.5, "population": 326586 },
-  { "name": "Riverside", "area": 81.2, "population": 325695 },
-  { "name": "St. Louis", "area": 160.8, "population": 319294 },
-  { "name": "Lexington", "area": 283.6, "population": 318449 },
-  { "name": "Stockton", "area": 61.7, "population": 312697 },
-  { "name": "Pittsburgh", "area": 58.3, "population": 302971 },
-  { "name": "Saint Paul", "area": 56.2, "population": 308096 },
-  { "name": "Cincinnati", "area": 77.9, "population": 301301 },
-  { "name": "Anchorage", "area": 1961, "population": 288000 },
-  { "name": "Henderson", "area": 104.7, "population": 310390 },
-  { "name": "Greensboro", "area": 131.2, "population": 299035 },
-  { "name": "Plano", "area": 71.6, "population": 287677 },
-  { "name": "Newark", "area": 26.1, "population": 282090 },
-  { "name": "Lincoln", "area": 89.1, "population": 281458 },
-  { "name": "Orlando", "area": 105.2, "population": 287442 },
-  { "name": "Irvine", "area": 66.1, "population": 280202 },
-  { "name": "Toledo", "area": 80.7, "population": 278508 },
-  { "name": "Jersey City", "area": 21.8, "population": 276427 },
-  { "name": "Chula Vista", "area": 49.6, "population": 270471 },
-  { "name": "Durham", "area": 108.3, "population": 267743 },
-  { "name": "Fort Wayne", "area": 110.6, "population": 265904 },
-  { "name": "St. Petersburg", "area": 61.7, "population": 265098 },
-  { "name": "Laredo", "area": 101.1, "population": 264295 },
-  { "name": "Buffalo", "area": 52.5, "population": 256480 },
-  { "name": "Madison", "area": 94, "population": 255214 },
-  { "name": "Lubbock", "area": 123.6, "population": 252506 },
-  { "name": "Chandler", "area": 64.9, "population": 252692 },
-  { "name": "Scottsdale", "area": 184.4, "population": 249950 },
-  { "name": "Glendale", "area": 59.1, "population": 249950 },
-  { "name": "Reno", "area": 108.7, "population": 248853 },
-  { "name": "Norfolk", "area": 53.3, "population": 247189 },
-  { "name": "Winston-Salem", "area": 132.4, "population": 246328 },
-  { "name": "North Las Vegas", "area": 101.3, "population": 245949 },
-  { "name": "Irving", "area": 67, "population": 245346 },
-  { "name": "Chesapeake", "area": 340.8, "population": 244835 },
-  { "name": "Gilbert", "area": 68, "population": 242354 },
-  { "name": "Hialeah", "area": 21.5, "population": 241769 },
-  { "name": "Garland", "area": 57.7, "population": 239928 },
-  { "name": "Fremont", "area": 77.5, "population": 239867 },
-  { "name": "Baton Rouge", "area": 76.8, "population": 227715 },
-  { "name": "Richmond", "area": 59.8, "population": 227032 },
-  { "name": "Boise", "area": 82.1, "population": 226570 },
-  { "name": "San Bernardino", "area": 59.2, "population": 224231 },
-  { "name": "Spokane", "area": 68.7, "population": 223266 },
-  { "name": "Des Moines", "area": 90.9, "population": 216853 },
-  { "name": "Tacoma", "area": 50, "population": 216279 },
-  { "name": "Fontana", "area": 43, "population": 214547 },
-  { "name": "Oxnard", "area": 26.9, "population": 214547 },
-  { "name": "Moreno Valley", "area": 51.3, "population": 213055 },
-  { "name": "Fayetteville", "area": 148.5, "population": 211354 },
-  { "name": "Aurora", "area": 154.6, "population": 372375 },
-  { "name": "Anaheim", "area": 50, "population": 359339 },
-  { "name": "Honolulu", "area": 68.4, "population": 345064 },
-  { "name": "Santa Ana", "area": 27.5, "population": 332725 },
-  { "name": "Corpus Christi", "area": 380.5, "population": 326586 },
-  { "name": "Riverside", "area": 81.2, "population": 325695 },
-  { "name": "St. Louis", "area": 160.8, "population": 319294 },
-  { "name": "Lexington", "area": 283.6, "population": 318449 },
-  { "name": "Stockton", "area": 61.7, "population": 312697 },
-  { "name": "Pittsburgh", "area": 58.3, "population": 302971 },
-  { "name": "Saint Paul", "area": 56.2, "population": 308096 },
-  { "name": "Cincinnati", "area": 77.9, "population": 301301 },
-  { "name": "Anchorage", "area": 1961, "population": 288000 },
-  { "name": "Henderson", "area": 104.7, "population": 310390 },
-  { "name": "Greensboro", "area": 131.2, "population": 299035 },
-  { "name": "Plano", "area": 71.6, "population": 287677 },
-  { "name": "Newark", "area": 26.1, "population": 282090 },
-  { "name": "Lincoln", "area": 89.1, "population": 281458 },
-  { "name": "Orlando", "area": 105.2, "population": 287442 },
-  { "name": "Irvine", "area": 66.1, "population": 280202 },
-  { "name": "Toledo", "area": 80.7, "population": 278508 },
-  { "name": "Jersey City", "area": 21.8, "population": 276427 },
-  { "name": "Chula Vista", "area": 49.6, "population": 270471 },
-  { "name": "Durham", "area": 108.3, "population": 267743 },
-  { "name": "Fort Wayne", "area": 110.6, "population": 265904 },
-  { "name": "St. Petersburg", "area": 61.7, "population": 265098 },
-  { "name": "Laredo", "area": 101.1, "population": 264295 },
-  { "name": "Buffalo", "area": 52.5, "population": 256480 },
-  { "name": "Madison", "area": 94, "population": 255214 },
-  { "name": "Lubbock", "area": 123.6, "population": 252506 },
-  { "name": "Chandler", "area": 64.9, "population": 252692 },
-  { "name": "Scottsdale", "area": 184.4, "population": 249950 },
-  { "name": "Glendale", "area": 59.1, "population": 249950 },
-  { "name": "Reno", "area": 108.7, "population": 248853 },
-  { "name": "Norfolk", "area": 53.3, "population": 247189 },
-  { "name": "Winston-Salem", "area": 132.4, "population": 246328 },
-  { "name": "North Las Vegas", "area": 101.3, "population": 245949 },
-  { "name": "Irving", "area": 67, "population": 245346 },
-  { "name": "Chesapeake", "area": 340.8, "population": 244835 },
-  { "name": "Gilbert", "area": 68, "population": 242354 },
-  { "name": "Hialeah", "area": 21.5, "population": 241769 },
-  { "name": "Garland", "area": 57.7, "population": 239928 },
-  { "name": "Fremont", "area": 77.5, "population": 239867 },
-  { "name": "Baton Rouge", "area": 76.8, "population": 227715 },
-  { "name": "Richmond", "area": 59.8, "population": 227032 },
-  { "name": "Boise", "area": 82.1, "population": 226570 },
-  { "name": "San Bernardino", "area": 59.2, "population": 224231 },
-  { "name": "Spokane", "area": 68.7, "population": 223266 },
-  { "name": "Des Moines", "area": 90.9, "population": 216853 },
-  { "name": "Tacoma", "area": 50, "population": 216279 },
-  { "name": "Fontana", "area": 43, "population": 214547 },
-  { "name": "Oxnard", "area": 26.9, "population": 214547 },
-  { "name": "Moreno Valley", "area": 51.3, "population": 213055 },
-  { "name": "Fayetteville", "area": 148.5, "population": 211354 },
-  { "name": "Aurora", "area": 154.6, "population": 372375 },
-  { "name": "Anaheim", "area": 50, "population": 359339 },
-  { "name": "Honolulu", "area": 68.4, "population": 345064 },
-  { "name": "Santa Ana", "area": 27.5, "population": 332725 },
-  { "name": "Corpus Christi", "area": 380.5, "population": 326586 },
-  { "name": "Riverside", "area": 81.2, "population": 325695 },
-  { "name": "St. Louis", "area": 160.8, "population": 319294 },
-  { "name": "Lexington", "area": 283.6, "population": 318449 },
-  { "name": "Stockton", "area": 61.7, "population": 312697 },
-  { "name": "Pittsburgh", "area": 58.3, "population": 302971 },
-  { "name": "Saint Paul", "area": 56.2, "population": 308096 },
-  { "name": "Cincinnati", "area": 77.9, "population": 301301 },
-  { "name": "Anchorage", "area": 1961, "population": 288000 },
-  { "name": "Henderson", "area": 104.7, "population": 310390 },
-  { "name": "Greensboro", "area": 131.2, "population": 299035 },
-  { "name": "Plano", "area": 71.6, "population": 287677 },
-  { "name": "Newark", "area": 26.1, "population": 282090 },
-  { "name": "Lincoln", "area": 89.1, "population": 281458 },
-  { "name": "Orlando", "area": 105.2, "population": 287442 },
-  { "name": "Irvine", "area": 66.1, "population": 280202 },
-  { "name": "Toledo", "area": 80.7, "population": 278508 },
-  { "name": "Jersey City", "area": 21.8, "population": 276427 },
-  { "name": "Chula Vista", "area": 49.6, "population": 270471 },
-  { "name": "Durham", "area": 108.3, "population": 267743 },
-  { "name": "Fort Wayne", "area": 110.6, "population": 265904 },
-  { "name": "St. Petersburg", "area": 61.7, "population": 265098 },
-  { "name": "Laredo", "area": 101.1, "population": 264295 },
-  { "name": "Buffalo", "area": 52.5, "population": 256480 },
-  { "name": "Madison", "area": 94, "population": 255214 },
-  { "name": "Lubbock", "area": 123.6, "population": 252506 },
-  { "name": "Chandler", "area": 64.9, "population": 252692 },
-  { "name": "Scottsdale", "area": 184.4, "population": 249950 },
-  { "name": "Glendale", "area": 59.1, "population": 249950 },
-  { "name": "Reno", "area": 108.7, "population": 248853 },
-  { "name": "Norfolk", "area": 53.3, "population": 247189 },
-  { "name": "Winston-Salem", "area": 132.4, "population": 246328 },
-  { "name": "North Las Vegas", "area": 101.3, "population": 245949 },
-  { "name": "Irving", "area": 67, "population": 245346 },
-  { "name": "Chesapeake", "area": 340.8, "population": 244835 },
-  { "name": "Gilbert", "area": 68, "population": 242354 },
-  { "name": "Hialeah", "area": 21.5, "population": 241769 },
-  { "name": "Garland", "area": 57.7, "population": 239928 },
-  { "name": "Fremont", "area": 77.5, "population": 239867 },
-  { "name": "Baton Rouge", "area": 76.8, "population": 227715 },
-  { "name": "Richmond", "area": 59.8, "population": 227032 },
-  { "name": "Boise", "area": 82.1, "population": 226570 },
-  { "name": "San Bernardino", "area": 59.2, "population": 224231 },
-  { "name": "Spokane", "area": 68.7, "population": 223266 },
-  { "name": "Des Moines", "area": 90.9, "population": 216853 },
-  { "name": "Tacoma", "area": 50, "population": 216279 },
-  { "name": "Fontana", "area": 43, "population": 214547 },
-  { "name": "Oxnard", "area": 26.9, "population": 214547 },
-  { "name": "Moreno Valley", "area": 51.3, "population": 213055 },
-  { "name": "Fayetteville", "area": 148.5, "population": 211354 }
+  {
+    "name": "New York",
+    "area": 468.9,
+    "population": 8398748,
+    "density": 6915.7
+  },
+  {
+    "name": "Los Angeles",
+    "area": 468.7,
+    "population": 3990456,
+    "density": 3287.23
+  },
+  {
+    "name": "Chicago",
+    "area": 227.3,
+    "population": 2705994,
+    "density": 4596.52
+  },
+  {
+    "name": "Houston",
+    "area": 599.6,
+    "population": 2320268,
+    "density": 1494.1
+  },
+  {
+    "name": "Phoenix",
+    "area": 517.6,
+    "population": 1680992,
+    "density": 1253.93
+  },
+  {
+    "name": "Philadelphia",
+    "area": 369.4,
+    "population": 1584064,
+    "density": 1655.69
+  },
+  {
+    "name": "San Antonio",
+    "area": 461,
+    "population": 1547253,
+    "density": 1295.87
+  },
+  {
+    "name": "San Diego",
+    "area": 325.2,
+    "population": 1423851,
+    "density": 1690.5
+  },
+  {
+    "name": "Dallas",
+    "area": 340.5,
+    "population": 1343573,
+    "density": 1523.51
+  },
+  {
+    "name": "San Jose",
+    "area": 461.5,
+    "population": 1030119,
+    "density": 861.82
+  },
+  {
+    "name": "Austin",
+    "area": 312.7,
+    "population": 964254,
+    "density": 1190.6
+  },
+  {
+    "name": "Jacksonville",
+    "area": 874.6,
+    "population": 903889,
+    "density": 399.03
+  },
+  {
+    "name": "Fort Worth",
+    "area": 347.2,
+    "population": 895008,
+    "density": 995.29
+  },
+  {
+    "name": "Columbus",
+    "area": 560.5,
+    "population": 892533,
+    "density": 614.82
+  },
+  {
+    "name": "Charlotte",
+    "area": 306.6,
+    "population": 885708,
+    "density": 1115.37
+  },
+  {
+    "name": "San Francisco",
+    "area": 121.4,
+    "population": 883305,
+    "density": 2809.27
+  },
+  {
+    "name": "Indianapolis",
+    "area": 368.2,
+    "population": 877584,
+    "density": 920.25
+  },
+  {
+    "name": "Seattle",
+    "area": 217.2,
+    "population": 753675,
+    "density": 1339.76
+  },
+  {
+    "name": "Denver",
+    "area": 401.2,
+    "population": 727211,
+    "density": 699.84
+  },
+  {
+    "name": "Washington",
+    "area": 177,
+    "population": 705749,
+    "density": 1539.5
+  },
+  {
+    "name": "Boston",
+    "area": 89.6,
+    "population": 694583,
+    "density": 2993.08
+  },
+  {
+    "name": "El Paso",
+    "area": 255.2,
+    "population": 681728,
+    "density": 1031.41
+  },
+  {
+    "name": "Nashville",
+    "area": 475,
+    "population": 670820,
+    "density": 545.27
+  },
+  {
+    "name": "Detroit",
+    "area": 370,
+    "population": 670031,
+    "density": 699.19
+  },
+  {
+    "name": "Oklahoma City",
+    "area": 620.3,
+    "population": 655057,
+    "density": 407.74
+  },
+  {
+    "name": "Portland",
+    "area": 133.5,
+    "population": 654741,
+    "density": 1893.61
+  },
+  {
+    "name": "Las Vegas",
+    "area": 352,
+    "population": 651319,
+    "density": 714.42
+  },
+  {
+    "name": "Memphis",
+    "area": 317.4,
+    "population": 650618,
+    "density": 791.45
+  },
+  {
+    "name": "Louisville",
+    "area": 263.5,
+    "population": 617638,
+    "density": 905.01
+  },
+  {
+    "name": "Baltimore",
+    "area": 80.9,
+    "population": 593490,
+    "density": 2832.48
+  },
+  {
+    "name": "Milwaukee",
+    "area": 249.9,
+    "population": 590157,
+    "density": 911.81
+  },
+  {
+    "name": "Albuquerque",
+    "area": 188.2,
+    "population": 560218,
+    "density": 1149.32
+  },
+  {
+    "name": "Tucson",
+    "area": 230.8,
+    "population": 548073,
+    "density": 916.86
+  },
+  {
+    "name": "Fresno",
+    "area": 114.6,
+    "population": 538330,
+    "density": 1813.7
+  },
+  {
+    "name": "Mesa",
+    "area": 325.5,
+    "population": 528159,
+    "density": 626.49
+  },
+  {
+    "name": "Sacramento",
+    "area": 97.9,
+    "population": 513624,
+    "density": 2025.65
+  },
+  {
+    "name": "Atlanta",
+    "area": 343,
+    "population": 506811,
+    "density": 570.5
+  },
+  {
+    "name": "Kansas City",
+    "area": 319,
+    "population": 495327,
+    "density": 599.52
+  },
+  {
+    "name": "Colorado Springs",
+    "area": 195.6,
+    "population": 478221,
+    "density": 943.98
+  },
+  {
+    "name": "Miami",
+    "area": 55.2,
+    "population": 467963,
+    "density": 3273.21
+  },
+  {
+    "name": "Raleigh",
+    "area": 146.9,
+    "population": 464485,
+    "density": 1220.82
+  },
+  {
+    "name": "Omaha",
+    "area": 133.4,
+    "population": 465112,
+    "density": 1346.18
+  },
+  {
+    "name": "Long Beach",
+    "area": 134,
+    "population": 470130,
+    "density": 1354.61
+  },
+  {
+    "name": "Virginia Beach",
+    "area": 245.6,
+    "population": 452745,
+    "density": 711.75
+  },
+  {
+    "name": "Oakland",
+    "area": 55.9,
+    "population": 440646,
+    "density": 3043.55
+  },
+  {
+    "name": "Minneapolis",
+    "area": 142.9,
+    "population": 429606,
+    "density": 1160.75
+  },
+  {
+    "name": "Tulsa",
+    "area": 196.8,
+    "population": 413066,
+    "density": 810.39
+  },
+  {
+    "name": "Arlington",
+    "area": 99,
+    "population": 398854,
+    "density": 1555.54
+  },
+  {
+    "name": "New Orleans",
+    "area": 169.4,
+    "population": 390845,
+    "density": 890.83
+  },
+  {
+    "name": "Wichita",
+    "area": 159.3,
+    "population": 389255,
+    "density": 943.45
+  },
+  {
+    "name": "Cleveland",
+    "area": 77.7,
+    "population": 381009,
+    "density": 1893.29
+  },
+  {
+    "name": "Tampa",
+    "area": 170.6,
+    "population": 377165,
+    "density": 853.6
+  },
+  {
+    "name": "Bakersfield",
+    "area": 142.6,
+    "population": 373640,
+    "density": 1011.66
+  },
+  {
+    "name": "Aurora",
+    "area": 154.6,
+    "population": 372375,
+    "density": 929.98
+  },
+  {
+    "name": "Anaheim",
+    "area": 50,
+    "population": 359339,
+    "density": 2774.83
+  },
+  {
+    "name": "Honolulu",
+    "area": 68.4,
+    "population": 345064,
+    "density": 1947.8
+  },
+  {
+    "name": "Santa Ana",
+    "area": 27.5,
+    "population": 332725,
+    "density": 4671.48
+  },
+  {
+    "name": "Corpus Christi",
+    "area": 380.5,
+    "population": 326586,
+    "density": 331.39
+  },
+  {
+    "name": "Riverside",
+    "area": 81.2,
+    "population": 325695,
+    "density": 1548.66
+  },
+  {
+    "name": "St. Louis",
+    "area": 160.8,
+    "population": 319294,
+    "density": 766.67
+  },
+  {
+    "name": "Lexington",
+    "area": 283.6,
+    "population": 318449,
+    "density": 433.55
+  },
+  {
+    "name": "Stockton",
+    "area": 61.7,
+    "population": 312697,
+    "density": 1956.77
+  },
+  {
+    "name": "Pittsburgh",
+    "area": 58.3,
+    "population": 302971,
+    "density": 2006.48
+  },
+  {
+    "name": "Saint Paul",
+    "area": 56.2,
+    "population": 308096,
+    "density": 2116.66
+  },
+  {
+    "name": "Cincinnati",
+    "area": 77.9,
+    "population": 301301,
+    "density": 1493.36
+  },
+  {
+    "name": "Anchorage",
+    "area": 1961,
+    "population": 288000,
+    "density": 56.7
+  },
+  {
+    "name": "Henderson",
+    "area": 104.7,
+    "population": 310390,
+    "density": 1144.62
+  },
+  {
+    "name": "Greensboro",
+    "area": 131.2,
+    "population": 299035,
+    "density": 880.02
+  },
+  {
+    "name": "Plano",
+    "area": 71.6,
+    "population": 287677,
+    "density": 1551.29
+  },
+  {
+    "name": "Newark",
+    "area": 26.1,
+    "population": 282090,
+    "density": 4173.01
+  },
+  {
+    "name": "Lincoln",
+    "area": 89.1,
+    "population": 281458,
+    "density": 1219.66
+  },
+  {
+    "name": "Orlando",
+    "area": 105.2,
+    "population": 287442,
+    "density": 1054.96
+  },
+  {
+    "name": "Irvine",
+    "area": 66.1,
+    "population": 280202,
+    "density": 1636.71
+  },
+  {
+    "name": "Toledo",
+    "area": 80.7,
+    "population": 278508,
+    "density": 1332.5
+  },
+  {
+    "name": "Jersey City",
+    "area": 21.8,
+    "population": 276427,
+    "density": 4895.82
+  },
+  {
+    "name": "Chula Vista",
+    "area": 49.6,
+    "population": 270471,
+    "density": 2105.43
+  },
+  {
+    "name": "Durham",
+    "area": 108.3,
+    "population": 267743,
+    "density": 954.53
+  },
+  {
+    "name": "Fort Wayne",
+    "area": 110.6,
+    "population": 265904,
+    "density": 928.26
+  },
+  {
+    "name": "St. Petersburg",
+    "area": 61.7,
+    "population": 265098,
+    "density": 1658.91
+  },
+  {
+    "name": "Laredo",
+    "area": 101.1,
+    "population": 264295,
+    "density": 1009.35
+  },
+  {
+    "name": "Buffalo",
+    "area": 52.5,
+    "population": 256480,
+    "density": 1886.24
+  },
+  {
+    "name": "Madison",
+    "area": 94,
+    "population": 255214,
+    "density": 1048.28
+  },
+  {
+    "name": "Lubbock",
+    "area": 123.6,
+    "population": 252506,
+    "density": 788.78
+  },
+  {
+    "name": "Chandler",
+    "area": 64.9,
+    "population": 252692,
+    "density": 1503.31
+  },
+  {
+    "name": "Scottsdale",
+    "area": 184.4,
+    "population": 249950,
+    "density": 523.35
+  },
+  {
+    "name": "Glendale",
+    "area": 59.1,
+    "population": 249950,
+    "density": 1632.93
+  },
+  {
+    "name": "Reno",
+    "area": 108.7,
+    "population": 248853,
+    "density": 883.92
+  },
+  {
+    "name": "Norfolk",
+    "area": 53.3,
+    "population": 247189,
+    "density": 1790.62
+  },
+  {
+    "name": "Winston-Salem",
+    "area": 132.4,
+    "population": 246328,
+    "density": 718.34
+  },
+  {
+    "name": "North Las Vegas",
+    "area": 101.3,
+    "population": 245949,
+    "density": 937.43
+  },
+  {
+    "name": "Irving",
+    "area": 67,
+    "population": 245346,
+    "density": 1413.86
+  },
+  {
+    "name": "Chesapeake",
+    "area": 340.8,
+    "population": 244835,
+    "density": 277.38
+  },
+  {
+    "name": "Gilbert",
+    "area": 68,
+    "population": 242354,
+    "density": 1376.08
+  },
+  {
+    "name": "Hialeah",
+    "area": 21.5,
+    "population": 241769,
+    "density": 4341.74
+  },
+  {
+    "name": "Garland",
+    "area": 57.7,
+    "population": 239928,
+    "density": 1605.49
+  },
+  {
+    "name": "Fremont",
+    "area": 77.5,
+    "population": 239867,
+    "density": 1195.01
+  },
+  {
+    "name": "Baton Rouge",
+    "area": 76.8,
+    "population": 227715,
+    "density": 1144.81
+  },
+  {
+    "name": "Richmond",
+    "area": 59.8,
+    "population": 227032,
+    "density": 1465.84
+  },
+  {
+    "name": "Boise",
+    "area": 82.1,
+    "population": 226570,
+    "density": 1065.52
+  },
+  {
+    "name": "San Bernardino",
+    "area": 59.2,
+    "population": 224231,
+    "density": 1462.43
+  },
+  {
+    "name": "Spokane",
+    "area": 68.7,
+    "population": 223266,
+    "density": 1254.78
+  },
+  {
+    "name": "Des Moines",
+    "area": 90.9,
+    "population": 216853,
+    "density": 921.09
+  },
+  {
+    "name": "Tacoma",
+    "area": 50,
+    "population": 216279,
+    "density": 1670.11
+  },
+  {
+    "name": "Fontana",
+    "area": 43,
+    "population": 214547,
+    "density": 1926.44
+  },
+  {
+    "name": "Oxnard",
+    "area": 26.9,
+    "population": 214547,
+    "density": 3079.44
+  },
+  {
+    "name": "Moreno Valley",
+    "area": 51.3,
+    "population": 213055,
+    "density": 1603.53
+  },
+  {
+    "name": "Fayetteville",
+    "area": 148.5,
+    "population": 211354,
+    "density": 549.52
+  },
+  {
+    "name": "Aurora",
+    "area": 154.6,
+    "population": 372375,
+    "density": 929.98
+  },
+  {
+    "name": "Anaheim",
+    "area": 50,
+    "population": 359339,
+    "density": 2774.83
+  },
+  {
+    "name": "Honolulu",
+    "area": 68.4,
+    "population": 345064,
+    "density": 1947.8
+  },
+  {
+    "name": "Santa Ana",
+    "area": 27.5,
+    "population": 332725,
+    "density": 4671.48
+  },
+  {
+    "name": "Corpus Christi",
+    "area": 380.5,
+    "population": 326586,
+    "density": 331.39
+  },
+  {
+    "name": "Riverside",
+    "area": 81.2,
+    "population": 325695,
+    "density": 1548.66
+  },
+  {
+    "name": "St. Louis",
+    "area": 160.8,
+    "population": 319294,
+    "density": 766.67
+  },
+  {
+    "name": "Lexington",
+    "area": 283.6,
+    "population": 318449,
+    "density": 433.55
+  },
+  {
+    "name": "Stockton",
+    "area": 61.7,
+    "population": 312697,
+    "density": 1956.77
+  },
+  {
+    "name": "Pittsburgh",
+    "area": 58.3,
+    "population": 302971,
+    "density": 2006.48
+  },
+  {
+    "name": "Saint Paul",
+    "area": 56.2,
+    "population": 308096,
+    "density": 2116.66
+  },
+  {
+    "name": "Cincinnati",
+    "area": 77.9,
+    "population": 301301,
+    "density": 1493.36
+  },
+  {
+    "name": "Anchorage",
+    "area": 1961,
+    "population": 288000,
+    "density": 56.7
+  },
+  {
+    "name": "Henderson",
+    "area": 104.7,
+    "population": 310390,
+    "density": 1144.62
+  },
+  {
+    "name": "Greensboro",
+    "area": 131.2,
+    "population": 299035,
+    "density": 880.02
+  },
+  {
+    "name": "Plano",
+    "area": 71.6,
+    "population": 287677,
+    "density": 1551.29
+  },
+  {
+    "name": "Newark",
+    "area": 26.1,
+    "population": 282090,
+    "density": 4173.01
+  },
+  {
+    "name": "Lincoln",
+    "area": 89.1,
+    "population": 281458,
+    "density": 1219.66
+  },
+  {
+    "name": "Orlando",
+    "area": 105.2,
+    "population": 287442,
+    "density": 1054.96
+  },
+  {
+    "name": "Irvine",
+    "area": 66.1,
+    "population": 280202,
+    "density": 1636.71
+  },
+  {
+    "name": "Toledo",
+    "area": 80.7,
+    "population": 278508,
+    "density": 1332.5
+  },
+  {
+    "name": "Jersey City",
+    "area": 21.8,
+    "population": 276427,
+    "density": 4895.82
+  },
+  {
+    "name": "Chula Vista",
+    "area": 49.6,
+    "population": 270471,
+    "density": 2105.43
+  },
+  {
+    "name": "Durham",
+    "area": 108.3,
+    "population": 267743,
+    "density": 954.53
+  },
+  {
+    "name": "Fort Wayne",
+    "area": 110.6,
+    "population": 265904,
+    "density": 928.26
+  },
+  {
+    "name": "St. Petersburg",
+    "area": 61.7,
+    "population": 265098,
+    "density": 1658.91
+  },
+  {
+    "name": "Laredo",
+    "area": 101.1,
+    "population": 264295,
+    "density": 1009.35
+  },
+  {
+    "name": "Buffalo",
+    "area": 52.5,
+    "population": 256480,
+    "density": 1886.24
+  },
+  {
+    "name": "Madison",
+    "area": 94,
+    "population": 255214,
+    "density": 1048.28
+  },
+  {
+    "name": "Lubbock",
+    "area": 123.6,
+    "population": 252506,
+    "density": 788.78
+  },
+  {
+    "name": "Chandler",
+    "area": 64.9,
+    "population": 252692,
+    "density": 1503.31
+  },
+  {
+    "name": "Scottsdale",
+    "area": 184.4,
+    "population": 249950,
+    "density": 523.35
+  },
+  {
+    "name": "Glendale",
+    "area": 59.1,
+    "population": 249950,
+    "density": 1632.93
+  },
+  {
+    "name": "Reno",
+    "area": 108.7,
+    "population": 248853,
+    "density": 883.92
+  },
+  {
+    "name": "Norfolk",
+    "area": 53.3,
+    "population": 247189,
+    "density": 1790.62
+  },
+  {
+    "name": "Winston-Salem",
+    "area": 132.4,
+    "population": 246328,
+    "density": 718.34
+  },
+  {
+    "name": "North Las Vegas",
+    "area": 101.3,
+    "population": 245949,
+    "density": 937.43
+  },
+  {
+    "name": "Irving",
+    "area": 67,
+    "population": 245346,
+    "density": 1413.86
+  },
+  {
+    "name": "Chesapeake",
+    "area": 340.8,
+    "population": 244835,
+    "density": 277.38
+  },
+  {
+    "name": "Gilbert",
+    "area": 68,
+    "population": 242354,
+    "density": 1376.08
+  },
+  {
+    "name": "Hialeah",
+    "area": 21.5,
+    "population": 241769,
+    "density": 4341.74
+  },
+  {
+    "name": "Garland",
+    "area": 57.7,
+    "population": 239928,
+    "density": 1605.49
+  },
+  {
+    "name": "Fremont",
+    "area": 77.5,
+    "population": 239867,
+    "density": 1195.01
+  },
+  {
+    "name": "Baton Rouge",
+    "area": 76.8,
+    "population": 227715,
+    "density": 1144.81
+  },
+  {
+    "name": "Richmond",
+    "area": 59.8,
+    "population": 227032,
+    "density": 1465.84
+  },
+  {
+    "name": "Boise",
+    "area": 82.1,
+    "population": 226570,
+    "density": 1065.52
+  },
+  {
+    "name": "San Bernardino",
+    "area": 59.2,
+    "population": 224231,
+    "density": 1462.43
+  },
+  {
+    "name": "Spokane",
+    "area": 68.7,
+    "population": 223266,
+    "density": 1254.78
+  },
+  {
+    "name": "Des Moines",
+    "area": 90.9,
+    "population": 216853,
+    "density": 921.09
+  },
+  {
+    "name": "Tacoma",
+    "area": 50,
+    "population": 216279,
+    "density": 1670.11
+  },
+  {
+    "name": "Fontana",
+    "area": 43,
+    "population": 214547,
+    "density": 1926.44
+  },
+  {
+    "name": "Oxnard",
+    "area": 26.9,
+    "population": 214547,
+    "density": 3079.44
+  },
+  {
+    "name": "Moreno Valley",
+    "area": 51.3,
+    "population": 213055,
+    "density": 1603.53
+  },
+  {
+    "name": "Fayetteville",
+    "area": 148.5,
+    "population": 211354,
+    "density": 549.52
+  },
+  {
+    "name": "Aurora",
+    "area": 154.6,
+    "population": 372375,
+    "density": 929.98
+  },
+  {
+    "name": "Anaheim",
+    "area": 50,
+    "population": 359339,
+    "density": 2774.83
+  },
+  {
+    "name": "Honolulu",
+    "area": 68.4,
+    "population": 345064,
+    "density": 1947.8
+  },
+  {
+    "name": "Santa Ana",
+    "area": 27.5,
+    "population": 332725,
+    "density": 4671.48
+  },
+  {
+    "name": "Corpus Christi",
+    "area": 380.5,
+    "population": 326586,
+    "density": 331.39
+  },
+  {
+    "name": "Riverside",
+    "area": 81.2,
+    "population": 325695,
+    "density": 1548.66
+  },
+  {
+    "name": "St. Louis",
+    "area": 160.8,
+    "population": 319294,
+    "density": 766.67
+  },
+  {
+    "name": "Lexington",
+    "area": 283.6,
+    "population": 318449,
+    "density": 433.55
+  },
+  {
+    "name": "Stockton",
+    "area": 61.7,
+    "population": 312697,
+    "density": 1956.77
+  },
+  {
+    "name": "Pittsburgh",
+    "area": 58.3,
+    "population": 302971,
+    "density": 2006.48
+  },
+  {
+    "name": "Saint Paul",
+    "area": 56.2,
+    "population": 308096,
+    "density": 2116.66
+  },
+  {
+    "name": "Cincinnati",
+    "area": 77.9,
+    "population": 301301,
+    "density": 1493.36
+  },
+  {
+    "name": "Anchorage",
+    "area": 1961,
+    "population": 288000,
+    "density": 56.7
+  },
+  {
+    "name": "Henderson",
+    "area": 104.7,
+    "population": 310390,
+    "density": 1144.62
+  },
+  {
+    "name": "Greensboro",
+    "area": 131.2,
+    "population": 299035,
+    "density": 880.02
+  },
+  {
+    "name": "Plano",
+    "area": 71.6,
+    "population": 287677,
+    "density": 1551.29
+  },
+  {
+    "name": "Newark",
+    "area": 26.1,
+    "population": 282090,
+    "density": 4173.01
+  },
+  {
+    "name": "Lincoln",
+    "area": 89.1,
+    "population": 281458,
+    "density": 1219.66
+  },
+  {
+    "name": "Orlando",
+    "area": 105.2,
+    "population": 287442,
+    "density": 1054.96
+  },
+  {
+    "name": "Irvine",
+    "area": 66.1,
+    "population": 280202,
+    "density": 1636.71
+  },
+  {
+    "name": "Toledo",
+    "area": 80.7,
+    "population": 278508,
+    "density": 1332.5
+  },
+  {
+    "name": "Jersey City",
+    "area": 21.8,
+    "population": 276427,
+    "density": 4895.82
+  },
+  {
+    "name": "Chula Vista",
+    "area": 49.6,
+    "population": 270471,
+    "density": 2105.43
+  },
+  {
+    "name": "Durham",
+    "area": 108.3,
+    "population": 267743,
+    "density": 954.53
+  },
+  {
+    "name": "Fort Wayne",
+    "area": 110.6,
+    "population": 265904,
+    "density": 928.26
+  },
+  {
+    "name": "St. Petersburg",
+    "area": 61.7,
+    "population": 265098,
+    "density": 1658.91
+  },
+  {
+    "name": "Laredo",
+    "area": 101.1,
+    "population": 264295,
+    "density": 1009.35
+  },
+  {
+    "name": "Buffalo",
+    "area": 52.5,
+    "population": 256480,
+    "density": 1886.24
+  },
+  {
+    "name": "Madison",
+    "area": 94,
+    "population": 255214,
+    "density": 1048.28
+  },
+  {
+    "name": "Lubbock",
+    "area": 123.6,
+    "population": 252506,
+    "density": 788.78
+  },
+  {
+    "name": "Chandler",
+    "area": 64.9,
+    "population": 252692,
+    "density": 1503.31
+  },
+  {
+    "name": "Scottsdale",
+    "area": 184.4,
+    "population": 249950,
+    "density": 523.35
+  },
+  {
+    "name": "Glendale",
+    "area": 59.1,
+    "population": 249950,
+    "density": 1632.93
+  },
+  {
+    "name": "Reno",
+    "area": 108.7,
+    "population": 248853,
+    "density": 883.92
+  },
+  {
+    "name": "Norfolk",
+    "area": 53.3,
+    "population": 247189,
+    "density": 1790.62
+  },
+  {
+    "name": "Winston-Salem",
+    "area": 132.4,
+    "population": 246328,
+    "density": 718.34
+  },
+  {
+    "name": "North Las Vegas",
+    "area": 101.3,
+    "population": 245949,
+    "density": 937.43
+  },
+  {
+    "name": "Irving",
+    "area": 67,
+    "population": 245346,
+    "density": 1413.86
+  },
+  {
+    "name": "Chesapeake",
+    "area": 340.8,
+    "population": 244835,
+    "density": 277.38
+  },
+  {
+    "name": "Gilbert",
+    "area": 68,
+    "population": 242354,
+    "density": 1376.08
+  },
+  {
+    "name": "Hialeah",
+    "area": 21.5,
+    "population": 241769,
+    "density": 4341.74
+  },
+  {
+    "name": "Garland",
+    "area": 57.7,
+    "population": 239928,
+    "density": 1605.49
+  },
+  {
+    "name": "Fremont",
+    "area": 77.5,
+    "population": 239867,
+    "density": 1195.01
+  },
+  {
+    "name": "Baton Rouge",
+    "area": 76.8,
+    "population": 227715,
+    "density": 1144.81
+  },
+  {
+    "name": "Richmond",
+    "area": 59.8,
+    "population": 227032,
+    "density": 1465.84
+  },
+  {
+    "name": "Boise",
+    "area": 82.1,
+    "population": 226570,
+    "density": 1065.52
+  },
+  {
+    "name": "San Bernardino",
+    "area": 59.2,
+    "population": 224231,
+    "density": 1462.43
+  },
+  {
+    "name": "Spokane",
+    "area": 68.7,
+    "population": 223266,
+    "density": 1254.78
+  },
+  {
+    "name": "Des Moines",
+    "area": 90.9,
+    "population": 216853,
+    "density": 921.09
+  },
+  {
+    "name": "Tacoma",
+    "area": 50,
+    "population": 216279,
+    "density": 1670.11
+  },
+  {
+    "name": "Fontana",
+    "area": 43,
+    "population": 214547,
+    "density": 1926.44
+  },
+  {
+    "name": "Oxnard",
+    "area": 26.9,
+    "population": 214547,
+    "density": 3079.44
+  },
+  {
+    "name": "Moreno Valley",
+    "area": 51.3,
+    "population": 213055,
+    "density": 1603.53
+  },
+  {
+    "name": "Fayetteville",
+    "area": 148.5,
+    "population": 211354,
+    "density": 549.52
+  }
 ]

--- a/server/tests/routes.test.js
+++ b/server/tests/routes.test.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 const app = require("../dist/index.js");
 
 describe("GET /api/cities", () => {
-  it("should receive correct result", async () => {
+  it("should receive correct result", () => {
     return request(app)
       .get("/api/cities")
       .expect("Content-Type", /json/)
@@ -12,7 +12,7 @@ describe("GET /api/cities", () => {
         expect(res.statusCode).toBe(200);
         expect(res.body.length).toBe(215);
 
-        fs.readFile("data/cities/cities.json", function (err, data) {
+        fs.readFile("tests/results.json", function (err, data) {
           if (err) {
             throw new Error(err);
           }

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -2,6 +2,16 @@ const fs = require("fs");
 const path = require("path");
 const csvParser = require("csv-parser");
 
+const computeDensity = (population: number, area: number) => {
+  const density = population / (area * 2.58999);
+  return Number(density.toFixed(2));
+};
+
+const enrich = (city: any) => ({
+  ...city,
+  density: computeDensity(Number(city.population), Number(city.area)),
+});
+
 const getData = async (name: string, type = "json", encoding = "utf-8") => {
   if (type !== "json" && type !== "csv") {
     throw new Error("File Type not supported");
@@ -22,7 +32,9 @@ const getData = async (name: string, type = "json", encoding = "utf-8") => {
 
 const getJSONData = async (filePath: string, encoding = "utf-8") => {
   const data = await fs.promises.readFile(filePath, encoding);
-  return JSON.parse(data);
+  const parsedData = JSON.parse(data);
+  const enrichedData = parsedData.map((city: any) => enrich(city));
+  return enrichedData;
 };
 
 const getCSVData = (
@@ -50,7 +62,7 @@ const getCSVData = (
       .on("error", (error: Error) => reject(error))
       .pipe(csvParser(newOptions))
       .on("error", (error: Error) => reject(error))
-      .on("data", (data: any) => results.push(data))
+      .on("data", (city: any) => results.push(enrich(city)))
       .on("end", () => resolve(results))
   );
 };


### PR DESCRIPTION
This pull request introduces a enhancement to the City Metrics project's `/api/cities` endpoint. It adds a new field, `density`, to the city data, calculated as the number of people per square kilometer. This feature enhances the richness of the data provided by our service, allowing for more comprehensive analysis and display on the front end.

### Key Enhancements

- Addition of the 'density' field in the city data response, calculated based on existing population and area fields.
- Dynamic calculation of density during data retrieval for both JSON and CSV data sources.

### Changes Made

- **Data Processing Logic:** Updated the logic in `utils.js` for processing city data to include density calculations.
- **Response Structure:** Modified the API response to include the new 'density' field.