### PR TITLE
Implement Sorting Functionality for /api/cities Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A coding challenge solution
 
 ### Endpoints
 
-- GET `/api/cities`: Returns a list of cities. The data is read from cities.json file located in the project root and enriched with a population `density` field.
+- GET `/api/cities`: Returns a list of cities. The data is read from cities.json file located in the project root and enriched with a population `density` field. Accepts sort and order query parameters. Valid sort fields are name, population, and area. The order can be ASC or DESC.
 
 #### Parameters
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,6 @@
 import express, { Express, Request, Response, NextFunction } from "express";
 import dotenv from "dotenv";
+import { SortDirection } from "./types";
 const asyncHandler = require("express-async-handler");
 const utils = require("./utils.js");
 
@@ -11,20 +12,30 @@ const port = process.env.PORT;
 app.get(
   "/api/cities",
   asyncHandler(async (req: Request, res: Response) => {
-    const { fileType, fileName } = req.query;
+    const { fileType, fileName, sort, order } = req.query;
 
     let headerFileType = req.get("Content-Type");
     headerFileType = headerFileType?.slice(headerFileType?.indexOf("/") + 1);
 
+    let data = [];
     try {
-      const data = await utils.getData(
+      data = await utils.getData(
         fileName || "cities",
         fileType || headerFileType
       );
-      res.json(data);
     } catch ({ message }: any) {
       res.send(`${message}`);
     }
+
+    if (!!sort) {
+      data = utils.sortData(
+        data,
+        sort,
+        ((order as string) || "").toUpperCase() || SortDirection.ASC
+      );
+    }
+
+    res.json(data);
   })
 );
 

--- a/server/tests/routes.test.js
+++ b/server/tests/routes.test.js
@@ -1,6 +1,26 @@
 const request = require("supertest");
 const fs = require("fs");
 const app = require("../dist/index.js");
+const { sortableFields, SortDirection } = require("../dist/types.js");
+
+const getAllSortings = () => {
+  const sortDirections = Object.values(SortDirection).filter((v) =>
+    isNaN(Number(v))
+  );
+
+  const allSortings = [];
+
+  sortableFields.forEach((sort) => {
+    sortDirections.forEach((order) => {
+      allSortings.push({
+        sort,
+        order,
+      });
+    });
+  });
+
+  return allSortings;
+};
 
 describe("GET /api/cities", () => {
   it("should receive correct result", () => {
@@ -20,4 +40,28 @@ describe("GET /api/cities", () => {
         });
       });
   });
+
+  it.each(getAllSortings())(
+    "should receive correct sorted data by %p",
+    async ({ sort, order }) => {
+      return request(app)
+        .get(`/api/cities?sort=${sort}&order=${order}`)
+        .expect("Content-Type", /json/)
+        .expect(200)
+        .then((res) => {
+          expect(res.statusCode).toBe(200);
+          expect(res.body.length).toBe(215);
+
+          fs.readFile(
+            `tests/sortedResults-${sort}-${order}.json`,
+            function (err, data) {
+              if (err) {
+                throw new Error(err);
+              }
+              expect(res.body).toMatchObject(JSON.parse(data));
+            }
+          );
+        });
+    }
+  );
 });


### PR DESCRIPTION
This pull request introduces sorting capabilities to the City Metrics project's `/api/cities` endpoint. It allows clients to sort city data by name, population, or area in both ascending and descending order. 

### Key Features Added

- Ability to sort city data by name, population, or area.
- Support for both ascending (ASC) and descending (DESC) sorting orders.
- Query parameter parsing for sorting functionality.

### Changes Made

- **Sorting Logic:** Implemented a `sortData` function in `utils.js` that handles the sorting of city data based on the provided query parameters.
- **Endpoint Enhancement:** Modified the `/api/cities` endpoint to accept sort and order query parameters and apply the sorting logic to the city data.
